### PR TITLE
Add Editor build configuration

### DIFF
--- a/TrombLoader.csproj
+++ b/TrombLoader.csproj
@@ -29,7 +29,7 @@
         <None Include="$(SolutionDir)thunderstore\icon.png" Pack="true" PackagePath="\" />
     </ItemGroup>
 
-    <ItemGroup>
+    <ItemGroup Condition="'$(Configuration)' != 'Editor'">
         <PackageReference Include="BepInEx.Analyzers" Version="1.*" PrivateAssets="all" />
         <PackageReference Include="BepInEx.Core" Version="5.*" />
         <PackageReference Include="BepInEx.PluginInfoProps" Version="1.*" />
@@ -41,8 +41,20 @@
 
     <ItemGroup>
         <PackageReference Include="TromboneChamp.GameLibs" Version="1.11.0" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(Configuration)' != 'Editor'">
         <PackageReference Include="TromboneChamp.BaboonAPI" Version="2.4.1" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(Configuration)' == 'Editor'">
+        <Compile Remove="Plugin.cs" />
+        <Compile Remove="CustomTracks/**" />
+        <Compile Remove="Patch/**" />
+        <Compile Remove="Helpers/Globals.cs" />
+        <Compile Remove="Helpers/ShaderHelper.cs" />
+        <Compile Remove="Data/TromboneEventInvoker.cs" />
     </ItemGroup>
 
     <ItemGroup>

--- a/TrombLoader.sln
+++ b/TrombLoader.sln
@@ -6,11 +6,14 @@ Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
+		Editor|Any CPU = Editor|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{31395BA8-67C3-47AF-8B3F-3B7A13D5E176}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{31395BA8-67C3-47AF-8B3F-3B7A13D5E176}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{31395BA8-67C3-47AF-8B3F-3B7A13D5E176}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{31395BA8-67C3-47AF-8B3F-3B7A13D5E176}.Release|Any CPU.Build.0 = Release|Any CPU
+		{31395BA8-67C3-47AF-8B3F-3B7A13D5E176}.Editor|Any CPU.ActiveCfg = Debug|Any CPU
+		{31395BA8-67C3-47AF-8B3F-3B7A13D5E176}.Editor|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Lets you build a version of TrombLoader for use in the Unity Editor for trombackgrounds.