### PR TITLE
add beatless tmb variable and patch

### DIFF
--- a/CustomTracks/CustomTrack.cs
+++ b/CustomTracks/CustomTrack.cs
@@ -27,6 +27,7 @@ public class CustomTrack : TromboneTrack, Previewable
     public string genre => _data.genre;
     public int difficulty => _data.difficulty;
     public int tempo => (int) _data.tempo;
+    public bool beatless => _data.beatless;
     public int length => Mathf.FloorToInt(_data.endpoint / (_data.tempo / 60f));
 
     public CustomTrack(string folderPath, CustomTrackData data, TrackLoader loader)

--- a/CustomTracks/CustomTrackData.cs
+++ b/CustomTracks/CustomTrackData.cs
@@ -17,6 +17,7 @@ public class CustomTrackData
     public string genre;
     public int difficulty;
     public float tempo;
+    public bool beatless = false;
     public string backgroundMovement = "none";
     public int savednotespacing;
     public int timesig;

--- a/Patch/BeatlessPatch.cs
+++ b/Patch/BeatlessPatch.cs
@@ -1,0 +1,23 @@
+using BaboonAPI.Hooks.Tracks;
+using HarmonyLib;
+using TrombLoader.CustomTracks;
+
+namespace TrombLoader.Patch;
+
+[HarmonyPatch]
+public class BeatlessPatch
+{
+    [HarmonyPatch(typeof(GameController), nameof(GameController.Start))]
+    [HarmonyPostfix]
+    static void PatchBeatless(GameController __instance)
+    {
+        var track = TrackLookup.lookup(GlobalVariables.chosen_track);
+        if (track is CustomTrack ct)
+        {
+            if (ct.beatless)
+            {
+                __instance.goBeatless();
+            }
+        }
+    }
+}


### PR DESCRIPTION
adds an optional `beatless` boolean field for custom charts. functions the same as it does on Mountain King and other base game tracks that use it. not quite variable BPM support but it's better than nothing i guess.