### PR TITLE
Chart Loader Optimization

### DIFF
--- a/CustomTracks/Backgrounds/VideoBackground.cs
+++ b/CustomTracks/Backgrounds/VideoBackground.cs
@@ -14,7 +14,7 @@ public class VideoBackground : HijackedBackground
     {
         _videoPath = videoPath;
     }
-    
+
     public override void SetUpBackground(BGController controller, GameObject bg)
     {
         DisableParts(bg);
@@ -56,10 +56,6 @@ public class VideoBackground : HijackedBackground
     public static IEnumerable<YieldInstruction> PlayVideoDelayed(VideoPlayer videoPlayer)
     {
         yield return new WaitForSeconds(2.4f);
-
-        if (videoPlayer != null)
-        {
-            videoPlayer.Play();
-        }
+        videoPlayer?.Play();
     }
 }

--- a/CustomTracks/ChartCompatibility.cs
+++ b/CustomTracks/ChartCompatibility.cs
@@ -36,7 +36,7 @@ public class ChartCompatibility
                 if (reader.TokenType is JsonToken.Float)
                 {
                     var chartName = (string) serializer.Context.Context;
-                    _logger.LogWarning($"Chart '{chartName}' has invalid type {reader.TokenType.ToString()} on field {_fieldName} (expected an integer)");
+                    _logger.LogWarning($"Chart '{chartName}' has invalid type {reader.TokenType} on field {_fieldName} (expected an integer)");
                 }
 
                 return (int) Convert.ToDouble(reader.Value);
@@ -44,7 +44,7 @@ public class ChartCompatibility
 
             if (reader.TokenType != JsonToken.Integer)
             {
-                throw new JsonException($"Expected number, got {reader.TokenType.ToString()}");
+                throw new JsonException($"Expected number, got {reader.TokenType}");
             }
 
             return Convert.ToInt32(reader.Value);

--- a/CustomTracks/CustomTrack.cs
+++ b/CustomTracks/CustomTrack.cs
@@ -38,7 +38,7 @@ public class CustomTrack : TromboneTrack, Previewable
 
     public SavedLevel LoadChart()
     {
-        return _loader?.ShouldReloadChart() == true ? _loader.ReloadTrack(this) : _data.ToSavedLevel();
+        return (bool)_loader?.ShouldReloadChart() ? _loader.ReloadTrack(this) : _data.ToSavedLevel();
     }
 
     public LoadedTromboneTrack LoadTrack()

--- a/CustomTracks/CustomTrack.cs
+++ b/CustomTracks/CustomTrack.cs
@@ -65,9 +65,10 @@ public class CustomTrack : TromboneTrack, Previewable
 
     private AbstractBackground LoadBackground()
     {
-        if (File.Exists(Path.Combine(folderPath, "bg.trombackground")))
+        var possibleBackgroundPath = Path.Combine(folderPath, "bg.trombackground");
+        if (File.Exists(possibleBackgroundPath))
         {
-            var bundle = AssetBundle.LoadFromFile(Path.Combine(folderPath, "bg.trombackground"));
+            var bundle = AssetBundle.LoadFromFile(possibleBackgroundPath);
             return new CustomBackground(bundle, folderPath);
         }
 

--- a/CustomTracks/TrackLoader.cs
+++ b/CustomTracks/TrackLoader.cs
@@ -26,6 +26,7 @@ public class TrackLoader : TrackRegistrationEvent.Listener
         var tmbDirectories = Directory.GetFiles(Globals.GetCustomSongsPath(), "song.tmb", SearchOption.AllDirectories);
         var seen = new HashSet<string>();
 
+        //For some reasons more thread ends up being much slower even than single threading, but using a low thread count makes it much faster
         Parallel.For(0, tmbDirectories.Length, new ParallelOptions() { MaxDegreeOfParallelism = 2 }, i =>
         {
             CustomTrackData customLevel;

--- a/CustomTracks/TrackLoader.cs
+++ b/CustomTracks/TrackLoader.cs
@@ -27,8 +27,6 @@ public class TrackLoader : TrackRegistrationEvent.Listener
         //Using more thread isn't faster, tested on 12 logical processor, best result using 3
         Parallel.For(0, songDirectories.Length, new ParallelOptions() { MaxDegreeOfParallelism = Environment.ProcessorCount / 4 }, i =>
         {
-            if (!File.Exists(songDirectories[i])) return;
-
             CustomTrackData customLevel;
             try
             {

--- a/CustomTracks/TrackLoader.cs
+++ b/CustomTracks/TrackLoader.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
@@ -13,6 +14,7 @@ public class TrackLoader : TrackRegistrationEvent.Listener
 {
     public IEnumerable<TromboneTrack> OnRegisterTracks()
     {
+        Stopwatch sw = Stopwatch.StartNew();
         CreateMissingDirectories();
 
         List<TromboneTrack> tracks = new List<TromboneTrack>();
@@ -24,8 +26,7 @@ public class TrackLoader : TrackRegistrationEvent.Listener
         var tmbDirectories = Directory.GetFiles(Globals.GetCustomSongsPath(), "song.tmb", SearchOption.AllDirectories);
         var seen = new HashSet<string>();
 
-        //Using more thread isn't faster, tested on 12 logical processor, best result using 3
-        Parallel.For(0, tmbDirectories.Length, new ParallelOptions() { MaxDegreeOfParallelism = Environment.ProcessorCount / 4 }, i =>
+        Parallel.For(0, tmbDirectories.Length, new ParallelOptions() { MaxDegreeOfParallelism = 2 }, i =>
         {
             CustomTrackData customLevel;
             string dirName;
@@ -57,6 +58,8 @@ public class TrackLoader : TrackRegistrationEvent.Listener
                     $"Skipping folder {dirName} as its trackref '{customLevel.trackRef}' was already loaded!");
             }
         });
+        sw.Stop();
+        Plugin.LogInfo($"{tracks.Count} charts were loaded in {sw.Elapsed.TotalMilliseconds:0.00}ms");
         return tracks;
     }
 

--- a/CustomTracks/TrackLoader.cs
+++ b/CustomTracks/TrackLoader.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
-using System.Threading.Tasks;
 using BaboonAPI.Hooks.Tracks;
 using Newtonsoft.Json;
 using TrombLoader.Helpers;
@@ -28,7 +27,7 @@ public class TrackLoader : TrackRegistrationEvent.Listener
         var seen = new HashSet<string>();
 
         //For some reasons more thread ends up being much slower even than single threading, but using a low thread count makes it much faster
-        Parallel.For(0, tmbDirectories.Length, new ParallelOptions() { MaxDegreeOfParallelism = 2 }, i =>
+        for(int i = 0; i < tmbDirectories.Length; i++)
         {
             CustomTrackData customLevel;
             string dirName;
@@ -45,7 +44,7 @@ public class TrackLoader : TrackRegistrationEvent.Listener
             {
                 Plugin.LogWarning($"Unable to deserialize JSON of custom chart: {tmbDirectories[i]}");
                 Plugin.LogWarning(exc.Message);
-                return;
+                continue;
             }
 
             if (seen.Add(customLevel.trackRef))
@@ -59,7 +58,7 @@ public class TrackLoader : TrackRegistrationEvent.Listener
                 Plugin.LogWarning(
                     $"Skipping folder {dirName} as its trackref '{customLevel.trackRef}' was already loaded!");
             }
-        });
+        };
         sw.Stop();
         Plugin.LogInfo($"{tracks.Count} charts were loaded in {sw.Elapsed.TotalMilliseconds:0.00}ms");
         return tracks.Where(x => x != null);

--- a/CustomTracks/TrackLoader.cs
+++ b/CustomTracks/TrackLoader.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
 using BaboonAPI.Hooks.Tracks;
@@ -38,7 +39,7 @@ public class TrackLoader : TrackRegistrationEvent.Listener
                 customLevel = JsonConvert.DeserializeObject<CustomTrackData>(File.ReadAllText(tmbDirectories[i]), new JsonSerializerSettings()
                 {
                     Context = new StreamingContext(StreamingContextStates.File, chartName)
-                });
+                }) ?? throw new Exception("Deserializer returned unexpected null value.");
             }
             catch (Exception exc)
             {
@@ -61,7 +62,7 @@ public class TrackLoader : TrackRegistrationEvent.Listener
         });
         sw.Stop();
         Plugin.LogInfo($"{tracks.Count} charts were loaded in {sw.Elapsed.TotalMilliseconds:0.00}ms");
-        return tracks;
+        return tracks.Where(x => x != null);
     }
 
     public SavedLevel ReloadTrack(CustomTrack existing)


### PR DESCRIPTION
# Main Changes
- Iterating through custom songs folder only
- Removed redundant customLevel null check
- Add tracks to a List then return that list as enumerable
- Removed serializer instance as it end up taking more memory anyway

# Testings
All testing were done using the DLL produced by the __released__ build on Visual Studio Community 2023 (fully updated) and the stable version of trombone champ on steam.
Multithreading testing (average time for ~1.2k charts):
Single Thread: average 3.8s
Multi Thread (Max 2): 2.4s
Multi Thread (Max 3): 2.2s
Multi Thread (Max 4): 3.6s
Multi Thread (Max 16): 7.8s

Also asked Sailent and Sierra to test Single Thread vs Multi Thread (2 and 3). Behavior was the same with 3 threads being marginally better than 2 and 2 being a huge improvement over single threading.

Sailent Results (average time for ~500 charts)
Single Thread: average 3.6s
Multi Thread (Max 2): 1.9s
Multi Thread (Max 3): 1.7s

Sierra Results (average time for ~500 charts)
Single Thread: average 3.2s
Multi Thread (Max 2): 2.7s
Multi Thread (Max 3): 2.4s
