### PR TITLE
Add manual dance support for trombackgrounds + add new background events

### DIFF
--- a/CustomTracks/Backgrounds/CustomBackground.cs
+++ b/CustomTracks/Backgrounds/CustomBackground.cs
@@ -207,6 +207,12 @@ public class CustomBackground : AbstractBackground
             {
                 tromboner.controller.show_rainbow = true;
             }
+
+            if (tromboner.placeholder.DanceMode == TrombonerDanceMode.DoNotOverride
+                && GlobalVariables.localsave.manual_dance)
+            {
+                tromboner.placeholder.DanceMode = TrombonerDanceMode.ManualDance;
+            }
         }
     }
 

--- a/Data/BackgroundPuppetController.cs
+++ b/Data/BackgroundPuppetController.cs
@@ -32,6 +32,17 @@ public class BackgroundPuppetController : MonoBehaviour
         }
     }
 
+    public void DoManualDance(float amount)
+    {
+        foreach (var tromboner in Tromboners)
+        {
+            if (tromboner.placeholder.DanceMode == TrombonerDanceMode.ManualDance)
+            {
+                tromboner.controller.doManualDance(amount);
+            }
+        }
+    }
+
     public void SetPuppetBreath(bool hasBreath)
     {
         foreach (var tromboner in Tromboners)

--- a/Data/TromboneEventInvoker.cs
+++ b/Data/TromboneEventInvoker.cs
@@ -21,6 +21,7 @@ namespace TrombLoader.Data
         private int previousCombo = 0;
         private int previousBGDataIndex = 0;
         private bool currentInputState = false;
+        private bool currentChampState = false;
 
         public void InitializeInvoker(GameController controller, TromboneEventManager[] eventManagers)
         {
@@ -110,6 +111,17 @@ namespace TrombLoader.Data
                 {
                     currentInputState = false;
                     foreach (var manager in _eventManagers) manager.PlayerTootInputEnd?.Invoke();
+                }
+            }
+
+            // champ mode on/off events
+            if (_controller.rainbowcontroller.champmode != currentChampState)
+            {
+                currentChampState = _controller.rainbowcontroller.champmode;
+                foreach (var manager in _eventManagers)
+                {
+                    if (currentChampState) manager.ChampModeActivated?.Invoke();
+                    else manager.ChampModeDeactivated?.Invoke();
                 }
             }
         }

--- a/Data/TromboneEventInvoker.cs
+++ b/Data/TromboneEventInvoker.cs
@@ -22,6 +22,7 @@ namespace TrombLoader.Data
         private int previousBGDataIndex = 0;
         private bool currentInputState = false;
         private bool currentChampState = false;
+        private bool outOfBreath = false;
 
         public void InitializeInvoker(GameController controller, TromboneEventManager[] eventManagers)
         {
@@ -122,6 +123,16 @@ namespace TrombLoader.Data
                 {
                     if (currentChampState) manager.ChampModeActivated?.Invoke();
                     else manager.ChampModeDeactivated?.Invoke();
+                }
+            }
+
+            // out of breath event
+            if (_controller.outofbreath != outOfBreath)
+            {
+                outOfBreath = _controller.outofbreath;
+                foreach (var manager in _eventManagers)
+                {
+                    if (outOfBreath) manager.OutOfBreath?.Invoke();
                 }
             }
         }

--- a/Data/TromboneEventManager.cs
+++ b/Data/TromboneEventManager.cs
@@ -27,6 +27,7 @@ namespace TrombLoader.Data
         public UnityEvent PlayerTootInputEnd;
         public UnityEvent ChampModeActivated;
         public UnityEvent ChampModeDeactivated;
+        public UnityEvent OutOfBreath;
 
         public IntEvent ComboUpdated;
         public Vector3Event MousePositionUpdated;

--- a/Data/TromboneEventManager.cs
+++ b/Data/TromboneEventManager.cs
@@ -25,6 +25,8 @@ namespace TrombLoader.Data
         public UnityEvent NoteEnd;
         public UnityEvent PlayerTootInputStart;
         public UnityEvent PlayerTootInputEnd;
+        public UnityEvent ChampModeActivated;
+        public UnityEvent ChampModeDeactivated;
 
         public IntEvent ComboUpdated;
         public Vector3Event MousePositionUpdated;

--- a/Data/TrombonerPlaceholder.cs
+++ b/Data/TrombonerPlaceholder.cs
@@ -11,6 +11,7 @@ namespace TrombLoader.Data
         public TromboneLength TromboneLength = TromboneLength.DoNotOverride;
         public TromboneHat TromboneHat = TromboneHat.DoNotOverride;
         public TrombonerMovementType MovementType = TrombonerMovementType.DoNotOverride;
+        public TrombonerDanceMode DanceMode = TrombonerDanceMode.DoNotOverride;
 
         [HideInInspector, SerializeField]
         public int InstanceID = 0;
@@ -108,5 +109,16 @@ namespace TrombLoader.Data
         Jubilant = 0,
         [InspectorName("Estudious")]
         Estudious = 1,
+    }
+
+    [Serializable]
+    public enum TrombonerDanceMode
+    {
+        [InspectorName("Do Not Override (Default)")]
+        DoNotOverride = -1,
+        [InspectorName("Auto Dance")]
+        AutoDance = 0,
+        [InspectorName("Manual Dance")]
+        ManualDance = 1,
     }
 }

--- a/Patch/PuppetControllerPatch.cs
+++ b/Patch/PuppetControllerPatch.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using System.Reflection.Emit;
 using HarmonyLib;
 using TrombLoader.Data;
+using UnityEngine;
 
 namespace TrombLoader.Patch
 {
@@ -42,6 +43,22 @@ namespace TrombLoader.Patch
             var puppetController = controller.bgcontroller.fullbgobject.GetComponent<BackgroundPuppetController>();
             // Multiply by 2 here to match basegame
             if (puppetController != null) puppetController.DoPuppetControl(vp * 2f, vibratoAmount);
+        }
+        
+        static void Postfix(GameController __instance)
+        {
+            var puppetController = __instance.bgcontroller.fullbgobject.GetComponent<BackgroundPuppetController>();
+            if (puppetController != null)
+            {
+                if (GlobalVariables.localsettings.mousecontrolmode <= 1)
+                {
+                    puppetController.DoManualDance(Input.GetAxis("Mouse X") * 1.25f * GlobalVariables.localsettings.sensitivity);
+                }
+                else
+                {
+                    puppetController.DoManualDance(Input.GetAxis("Mouse Y") * -1.25f * GlobalVariables.localsettings.sensitivity);
+                }
+            }
         }
 
         static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)

--- a/TrombLoader.csproj
+++ b/TrombLoader.csproj
@@ -40,7 +40,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="TromboneChamp.GameLibs" Version="1.14.0" />
+        <PackageReference Include="TromboneChamp.GameLibs" Version="1.19.0-beta" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(Configuration)' != 'Editor'">


### PR DESCRIPTION
The events are:
 - Champ Mode Activated
 - Champ Mode Deactivated
 - Out of Breath
 
They should be fairly self explanatory. 👀

I did look at adding an event for the game pointer similar to the mouse event but I encountered some weird problems when trying to implement it which is probably just skill issue on my end.

This also uses version `1.19.0-beta` of the gamelibs so you'll probably want to change that once 1.19 releases.