### PR TITLE
increase pixel light count to 16 from the default 4

### DIFF
--- a/Plugin.cs
+++ b/Plugin.cs
@@ -41,6 +41,7 @@ namespace TrombLoader
             TrackRegistrationEvent.EVENT.Register(new TrackLoader());
 
             ShaderHelper = new();
+            QualitySettings.pixelLightCount = 16;
         }
 
         private void TryInitialize()


### PR DESCRIPTION
this should allow custom backgrounds to more easily utilise multiple lights in the scene, especially when dealing with imported models that are stored as a single large mesh object. wasn't sure on what maximum to set but 16 seemed sensible enough.