### PR TITLE
Fix trombackground toot input events not respecting the 'keyboard-only tooting' game setting, fix input timing too by hopping off of the game's input handling

### DIFF
--- a/Data/TromboneEventInvoker.cs
+++ b/Data/TromboneEventInvoker.cs
@@ -98,7 +98,7 @@ namespace TrombLoader.Data
                 if (Input.GetKey(toot_key)) keysActive++;
             }
 
-            if(keysActive == 1 || Input.GetMouseButton(0))
+            if(keysActive == 1 || (Input.GetMouseButton(0) && !GlobalVariables.localsettings.disable_mouse_tooting))
             {
                 if(currentInputState == false)
                 {

--- a/Data/TromboneEventInvoker.cs
+++ b/Data/TromboneEventInvoker.cs
@@ -92,13 +92,11 @@ namespace TrombLoader.Data
             }
 
             // input start/end events
-            int keysActive = 0;
-            foreach(var toot_key in _controller.toot_keys)
-            {
-                if (Input.GetKey(toot_key)) keysActive++;
-            }
-
-            if(keysActive == 1 || (Input.GetMouseButton(0) && !GlobalVariables.localsettings.disable_mouse_tooting))
+            // We use `notebuttonpressed` here, over `isNoteButtonPressed()`, to preserve the game's behavior of
+            // releasing for one frame when, say, going from one key down to two keys down. Calling
+            // `isNoteButtonPressed()` multiple times in a frame (once in GameController, and again here) would break
+            // that.
+            if (_controller.notebuttonpressed)
             {
                 if(currentInputState == false)
                 {


### PR DESCRIPTION
Clicking would send toot events to a custom trombackground, even if the user had "Keyboard-only tooting" checked in the game settings. This fixes that.